### PR TITLE
Initial patch for enabling GUIDED mode and mission planning

### DIFF
--- a/blue_description/config/bluerov2/ardusub.parm
+++ b/blue_description/config/bluerov2/ardusub.parm
@@ -102,5 +102,18 @@ COMPASS_USE2 0        # Disable compass 2
 COMPASS_USE3 0        # Disable compass 3
 EK3_SRC1_YAW 6        # External nav
 
+# Enable external visual navigation
+EK2_ENABLE       0.000
+EK3_ENABLE       1.000
+AHRS_EKF_TYPE    3.000
+
+VISO_TYPE        1.000
+EK3_GPS_TYPE     3.000
+EK3_SRC1_POSXY   6.000
+EK3_SRC1_VELXY   6.000
+EK3_SRC1_POSZ    1.000
+EK3_SRC1_YAW     6.000
+EK3_SRC1_VELZ    6.000
+
 # See https://github.com/clydemcqueen/bluerov2_ignition/issues/7
 SIM_BARO_RND 0.01

--- a/blue_description/config/bluerov2_heavy/ardusub.parm
+++ b/blue_description/config/bluerov2_heavy/ardusub.parm
@@ -62,23 +62,18 @@ INS_ACC3SCAL_Y   1.000
 INS_ACC3SCAL_Z   1.000
 FRAME_CONFIG     2.000
 
-# Use EK3
-EK2_ENABLE 0
-EK3_ENABLE 1
-AHRS_EKF_TYPE 3
+# Enable external visual navigation
+EK2_ENABLE       0.000
+EK3_ENABLE       1.000
+AHRS_EKF_TYPE    3.000
 
-# Enable external nav
-# From https://ardupilot.org/copter/docs/common-vio-tracking-camera.html
-GPS_TYPE 0            # Disable GPS
-VISO_TYPE 1           # External vision
-EK3_SRC1_POSXY 6      # External nav
-EK3_SRC1_VELXY 6      # External nav
-EK3_SRC1_POSZ 1       # Baro is the primary z source
-EK3_SRC1_VELZ 6       # External nav z velocity influences EKF
-COMPASS_USE 0         # Disable compass 1
-COMPASS_USE2 0        # Disable compass 2
-COMPASS_USE3 0        # Disable compass 3
-EK3_SRC1_YAW 6        # External nav
+VISO_TYPE        1.000
+EK3_GPS_TYPE     3.000
+EK3_SRC1_POSXY   6.000
+EK3_SRC1_VELXY   6.000
+EK3_SRC1_POSZ    1.000
+EK3_SRC1_YAW     6.000
+EK3_SRC1_VELZ    6.000
 
 # See https://github.com/clydemcqueen/bluerov2_ignition/issues/7
 SIM_BARO_RND 0.01

--- a/blue_description/config/bluerov2_heavy_reach/ardusub.parm
+++ b/blue_description/config/bluerov2_heavy_reach/ardusub.parm
@@ -67,18 +67,18 @@ EK2_ENABLE 0
 EK3_ENABLE 1
 AHRS_EKF_TYPE 3
 
-# Enable external nav
-# From https://ardupilot.org/copter/docs/common-vio-tracking-camera.html
-GPS_TYPE 0            # Disable GPS
-VISO_TYPE 1           # External vision
-EK3_SRC1_POSXY 6      # External nav
-EK3_SRC1_VELXY 6      # External nav
-EK3_SRC1_POSZ 1       # Baro is the primary z source
-EK3_SRC1_VELZ 6       # External nav z velocity influences EKF
-COMPASS_USE 0         # Disable compass 1
-COMPASS_USE2 0        # Disable compass 2
-COMPASS_USE3 0        # Disable compass 3
-EK3_SRC1_YAW 6        # External nav
+# Enable external visual navigation
+EK2_ENABLE       0.000
+EK3_ENABLE       1.000
+AHRS_EKF_TYPE    3.000
+
+VISO_TYPE        1.000
+EK3_GPS_TYPE     3.000
+EK3_SRC1_POSXY   6.000
+EK3_SRC1_VELXY   6.000
+EK3_SRC1_POSZ    1.000
+EK3_SRC1_YAW     6.000
+EK3_SRC1_VELZ    6.000
 
 # See https://github.com/clydemcqueen/bluerov2_ignition/issues/7
 SIM_BARO_RND 0.01

--- a/blue_description/config/mavros.yaml
+++ b/blue_description/config/mavros.yaml
@@ -9,6 +9,8 @@ mavros:
       - rc_io
       - param
       - vision_pose
+      - setpoint_position
+      - setpoint_velocity
 
 mavros_node:
   ros__parameters:


### PR DESCRIPTION
# Checklist

- [x] I have performed a thorough review of my code
- [x] I have sufficiently commented my code
- [x] The implementation follows the project style conventions
- [x] All project unit tests are passing
- [x] If relevant, documentation has been provided or updated to discuss the changes made
- [x] System integration tests were performed successfully

## Changes Made

The ArduSub parameters loaded were modified due to their failure to enable the use of GUIDED mode and mission planning via QGroundControl. Furthermore, the `setpoint_position` and `setpoint_velocity` MAVROS plugins were added to enable sending commands to the vehicle while in GUIDED mode. From this, users can now switch into GUIDED mode to send commands via MAVROS and can also create missions within QGC for the ROV to execute.

 There are a few caveats in this initial patch, however:
1. The vehicle can fly? If you send a really large positive Z-position (above surface), the vehicle will somehow fly there. For those that try this out, ROS/MAVROS uses the conventional ENU frame, so when you send commands using MAVROS, make sure to send commands in the ENU frame.
2. I am still unable to select a location in QGC using the `Go to location` interface. When I try to use that functionality, QGC still indicates that the vehicle does not support GUIDED mode. Nonetheless, I can still set GUIDED mode and arm the vehicle.

## Associated Issues

- Fixes #63 

## Testing

Preliminary testing was done in SITL.