### PR TITLE
Allowing gazebo_world_file arg to be passed in

### DIFF
--- a/blue_bringup/launch/bluerov2/bluerov2.launch.py
+++ b/blue_bringup/launch/bluerov2/bluerov2.launch.py
@@ -133,7 +133,9 @@ def generate_launch_description() -> LaunchDescription:
                     "use_sim": LaunchConfiguration("use_sim"),
                     "use_rviz": LaunchConfiguration("use_rviz"),
                     "rviz_config": LaunchConfiguration("rviz_config"),
-                    "gazebo_world_file": LaunchConfiguration("gazebo_world_file", default="bluerov2_underwater.world"),
+                    "gazebo_world_file": LaunchConfiguration(
+                        "gazebo_world_file", default="bluerov2_underwater.world"
+                    ),
                     "prefix": LaunchConfiguration("prefix"),
                     "robot_description": robot_description,
                     "use_joy": LaunchConfiguration("use_joy"),

--- a/blue_bringup/launch/bluerov2/bluerov2.launch.py
+++ b/blue_bringup/launch/bluerov2/bluerov2.launch.py
@@ -133,7 +133,7 @@ def generate_launch_description() -> LaunchDescription:
                     "use_sim": LaunchConfiguration("use_sim"),
                     "use_rviz": LaunchConfiguration("use_rviz"),
                     "rviz_config": LaunchConfiguration("rviz_config"),
-                    "gazebo_world_file": "bluerov2_underwater.world",
+                    "gazebo_world_file": LaunchConfiguration("gazebo_world_file", default="bluerov2_underwater.world"),
                     "prefix": LaunchConfiguration("prefix"),
                     "robot_description": robot_description,
                     "use_joy": LaunchConfiguration("use_joy"),

--- a/blue_bringup/launch/bluerov2_heavy/bluerov2_heavy.launch.py
+++ b/blue_bringup/launch/bluerov2_heavy/bluerov2_heavy.launch.py
@@ -133,7 +133,7 @@ def generate_launch_description() -> LaunchDescription:
                     "use_sim": LaunchConfiguration("use_sim"),
                     "use_rviz": LaunchConfiguration("use_rviz"),
                     "rviz_config": LaunchConfiguration("rviz_config"),
-                    "gazebo_world_file": "bluerov2_heavy_underwater.world",
+                    "gazebo_world_file": LaunchConfiguration("gazebo_world_file", default="bluerov2_heavy_underwater.world"),
                     "prefix": LaunchConfiguration("prefix"),
                     "robot_description": robot_description,
                     "use_joy": LaunchConfiguration("use_joy"),

--- a/blue_bringup/launch/bluerov2_heavy/bluerov2_heavy.launch.py
+++ b/blue_bringup/launch/bluerov2_heavy/bluerov2_heavy.launch.py
@@ -133,7 +133,9 @@ def generate_launch_description() -> LaunchDescription:
                     "use_sim": LaunchConfiguration("use_sim"),
                     "use_rviz": LaunchConfiguration("use_rviz"),
                     "rviz_config": LaunchConfiguration("rviz_config"),
-                    "gazebo_world_file": LaunchConfiguration("gazebo_world_file", default="bluerov2_heavy_underwater.world"),
+                    "gazebo_world_file": LaunchConfiguration(
+                        "gazebo_world_file", default="bluerov2_heavy_underwater.world"
+                    ),
                     "prefix": LaunchConfiguration("prefix"),
                     "robot_description": robot_description,
                     "use_joy": LaunchConfiguration("use_joy"),

--- a/blue_bringup/launch/bluerov2_heavy_reach/bluerov2_heavy_reach.launch.py
+++ b/blue_bringup/launch/bluerov2_heavy_reach/bluerov2_heavy_reach.launch.py
@@ -133,7 +133,7 @@ def generate_launch_description() -> LaunchDescription:
                     "use_sim": LaunchConfiguration("use_sim"),
                     "use_rviz": LaunchConfiguration("use_rviz"),
                     "rviz_config": LaunchConfiguration("rviz_config"),
-                    "gazebo_world_file": "bluerov2_heavy_reach_underwater.world",  # noqa
+                    "gazebo_world_file": LaunchConfiguration("gazebo_world_file", default="bluerov2_heavy_reach_underwater.world"), # noqa
                     "prefix": LaunchConfiguration("prefix"),
                     "robot_description": robot_description,
                     "use_joy": LaunchConfiguration("use_joy"),

--- a/blue_bringup/launch/bluerov2_heavy_reach/bluerov2_heavy_reach.launch.py
+++ b/blue_bringup/launch/bluerov2_heavy_reach/bluerov2_heavy_reach.launch.py
@@ -133,7 +133,10 @@ def generate_launch_description() -> LaunchDescription:
                     "use_sim": LaunchConfiguration("use_sim"),
                     "use_rviz": LaunchConfiguration("use_rviz"),
                     "rviz_config": LaunchConfiguration("rviz_config"),
-                    "gazebo_world_file": LaunchConfiguration("gazebo_world_file", default="bluerov2_heavy_reach_underwater.world"), # noqa
+                    "gazebo_world_file": LaunchConfiguration(
+                        "gazebo_world_file",
+                        default="bluerov2_heavy_reach_underwater.world",
+                    ),  # noqa
                     "prefix": LaunchConfiguration("prefix"),
                     "robot_description": robot_description,
                     "use_joy": LaunchConfiguration("use_joy"),


### PR DESCRIPTION
Currently, when running `ros2 launch blue_bringup bluerov2.launch.py`, the `gazebo_world_file` argument is not supported.

This PR allows users to pass in the argument. If no argument is provided, `bluerov2_underwater.world` will be used. 