### PR TITLE
Upgrade Gazebo from Garden to Harmonic

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -99,14 +99,14 @@ RUN echo "source ${USER_WORKSPACE}/install/setup.bash" >> /home/$USERNAME/.bashr
 FROM robot as desktop
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GZ_VERSION=garden
+ENV GZ_VERSION=harmonic
 
-# Install Gazebo Garden: https://gazebosim.org/docs/garden/install_ubuntu
+# Install Gazebo Harmonic: https://gazebosim.org/docs/harmonic/install_ubuntu
 RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
     && sudo apt-get -q update \
     && sudo apt-get -y --quiet --no-install-recommends install \
-    gz-garden \
+    gz-harmonic \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,13 @@
 pull_request_rules:
+  - name: backport to jazzy at reviewers discretion
+    conditions:
+      - base=main
+      - "label=backport-jazzy"
+    actions:
+      backport:
+        branches:
+          - jazzy
+
   - name: backport to iron at reviewers discretion
     conditions:
       - base=main

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 33-feature-ros2-control
   pull_request:
     paths:
       - docs/**

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install clang-format-14
         run: sudo apt-get install clang-format-14

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
       "name": "Linux",
       "includePath": [
         "${workspaceFolder}/**",
-        "/opt/ros/iron/include/**",
+        "/opt/ros/rolling/include/**",
         "/usr/include/eigen3/**",
         "/home/ros/ws_ros/**"
       ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,13 +23,13 @@
   "autoDocstring.startOnNewLine": false,
   "autoDocstring.docstringFormat": "google-notypes",
   "python.autoComplete.extraPaths": [
-    "/opt/ros/iron/lib/python3.10/site-packages/",
-    "/opt/ros/iron/local/lib/python3.10/dist-packages/",
+    "/opt/ros/rolling/lib/python3.10/site-packages/",
+    "/opt/ros/rolling/local/lib/python3.10/dist-packages/",
     "${workspaceFolder}/install/"
   ],
   "python.analysis.extraPaths": [
-    "/opt/ros/iron/lib/python3.10/site-packages/",
-    "/opt/ros/iron/local/lib/python3.10/dist-packages/",
+    "/opt/ros/rolling/lib/python3.10/site-packages/",
+    "/opt/ros/rolling/local/lib/python3.10/dist-packages/",
     "${workspaceFolder}/install/"
   ],
   "[python]": {

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 # Installation
 
 Blue is currently supported on Linux and is available for the ROS distributions
-Humble and Iron. Blue can be installed from source or using one of
+Humble, Iron, and Jazzy. Blue can be installed from source or using one of
 the provided Docker images. If you plan to use Blue for simulation and have
 a system with limited compute power, we recommend installing Blue from source.
 For all other cases, we recommend installing Blue using Docker.
@@ -24,19 +24,19 @@ images](https://github.com/Robotic-Decision-Making-Lab/blue/pkgs/container/blue)
 A complete list of the provided images is documented below (where `*` should be
 replaced with the desired ROS distribution, e.g., `humble-robot`):
 
-| Supported ROS Versions | Image Tag | Build Architectures | Description |
-| ---------------------- | --------- | ------------------- | ----------- |
-| Humble, Iron | *-robot   | `amd64`, `arm64` | A bare-bones image that includes all dependencies without simulation or visualization features. This can be used to deploy Blue to hardware. |
-| Humble, Iron | *-desktop | `amd64` | Image that includes all dependencies, including simulation and visualization features. This can be used for development, testing, and top-side deployment. |
-| Humble, Iron | *-desktop-nvidia | `amd64` | Extension of the `*-desktop` image that provides support for NVIDIA GPU drivers. This image is *strongly* recommended for systems that have an NVIDIA GPU, and requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). |
+| Supported ROS Versions | Image Tag        | Build Architectures | Description                                                                                                                                                                                                                                                                                          |
+| ---------------------- | ---------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Humble, Iron, Jazzy    | *-robot          | `amd64`, `arm64`    | A bare-bones image that includes all dependencies without simulation or visualization features. This can be used to deploy Blue to hardware.                                                                                                                                                         |
+| Humble, Iron, Jazzy    | *-desktop        | `amd64`             | Image that includes all dependencies, including simulation and visualization features. This can be used for development, testing, and top-side deployment.                                                                                                                                           |
+| Humble, Iron, Jazzy    | *-desktop-nvidia | `amd64`             | Extension of the `*-desktop` image that provides support for NVIDIA GPU drivers. This image is *strongly* recommended for systems that have an NVIDIA GPU, and requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). |
 
 If you plan to use either the `*-desktop` or `*-desktop-nvidia` images, you may
 use the provided [Docker Compose scripts](https://github.com/Robotic-Decision-Making-Lab/blue/tree/main/.docker/compose)
-to install and run Blue. For instance, to pull and run the `iron-desktop` image,
+to install and run Blue. For instance, to pull and run the `jazzy-desktop` image,
 first run the command:
 
 ```bash
-wget https://raw.githubusercontent.com/Robotic-Decision-Making-Lab/blue/iron/.docker/compose/nouveau-desktop.yaml && \
+wget https://raw.githubusercontent.com/Robotic-Decision-Making-Lab/blue/jazzy/.docker/compose/nouveau-desktop.yaml && \
 docker compose -f nouveau-desktop.yaml up
 ```
 


### PR DESCRIPTION
## Changes Made

This PR upgrades the default Gazebo versions for the Jazzy and Rolling releases to be Harmonic instead of Garden. Iron and Humble will continue to use Garden.

## Associated Issues

- Fixes #170 

## Testing

No testing has been done yet.
