### PR TITLE
Resolved bug in BlueROV2 Heavy and Heavy Reach launch configurations

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -83,6 +83,7 @@ RUN sudo apt-get -q update \
     gstreamer1.0-libav \
     libgstreamer1.0-dev \
     gstreamer1.0-gl \
+    libgstreamer-plugins-base1.0-dev \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -81,6 +81,8 @@ RUN sudo apt-get -q update \
     gstreamer1.0-plugins-ugly \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-libav \
+    libgstreamer1.0-dev \
+    gstreamer1.0-gl \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*
@@ -118,6 +120,9 @@ RUN sudo apt-get -q update \
     python3-wxgtk4.0 \
     rapidjson-dev \
     xterm \
+    libgz-sim7-dev \
+    rapidjson-dev \
+    libopencv-dev \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/blue_bringup/launch/bluerov2_heavy/bluerov2_heavy.launch.yaml
+++ b/blue_bringup/launch/bluerov2_heavy/bluerov2_heavy.launch.yaml
@@ -43,7 +43,7 @@ launch:
 
   - arg:
       name: mavros_file
-      default: $(find-pkg-share blue_description)/config/mavros.yaml
+      default: $(find-pkg-share blue_description)/config/ardusub/mavros.yaml
 
   - arg:
       name: manager_file

--- a/blue_bringup/launch/bluerov2_heavy_reach/bluerov2_heavy_reach.launch.yaml
+++ b/blue_bringup/launch/bluerov2_heavy_reach/bluerov2_heavy_reach.launch.yaml
@@ -43,7 +43,7 @@ launch:
 
   - arg:
       name: mavros_file
-      default: $(find-pkg-share blue_description)/config/mavros.yaml
+      default: $(find-pkg-share blue_description)/config/ardusub/mavros.yaml
 
   - arg:
       name: manager_file

--- a/blue_demos/control_integration/launch/bluerov2_controllers.launch.py
+++ b/blue_demos/control_integration/launch/bluerov2_controllers.launch.py
@@ -76,6 +76,9 @@ def generate_launch_description() -> LaunchDescription:
                 ]
             ),
         ],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
     )
 
     velocity_controller_spawner = Node(

--- a/blue_demos/control_integration/launch/bluerov2_controllers.launch.py
+++ b/blue_demos/control_integration/launch/bluerov2_controllers.launch.py
@@ -21,12 +21,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import (
-    Command,
-    FindExecutable,
-    LaunchConfiguration,
-    PathJoinSubstitution,
-)
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -52,29 +47,6 @@ def generate_launch_description() -> LaunchDescription:
         ),
     ]
 
-    robot_description_content = Command(
-        [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
-            " ",
-            PathJoinSubstitution(
-                [
-                    FindPackageShare("blue_demos"),
-                    "control_integration",
-                    "description",
-                    "urdf",
-                    "bluerov2.config.xacro",
-                ]
-            ),
-            " ",
-            "prefix:=",
-            LaunchConfiguration("prefix"),
-            " ",
-            "use_sim:=",
-            LaunchConfiguration("use_sim"),
-        ]
-    )
-    robot_description = {"robot_description": robot_description_content}
-
     # The ISMC expects state information to be provided in the FSD frame
     mobile_to_maritime_velocity_state = Node(
         package="mobile_to_maritime",
@@ -95,7 +67,6 @@ def generate_launch_description() -> LaunchDescription:
         executable="ros2_control_node",
         output="both",
         parameters=[
-            robot_description,
             PathJoinSubstitution(
                 [
                     FindPackageShare("blue_demos"),

--- a/blue_demos/control_integration/launch/bluerov2_heavy_controllers.launch.py
+++ b/blue_demos/control_integration/launch/bluerov2_heavy_controllers.launch.py
@@ -75,6 +75,9 @@ def generate_launch_description() -> LaunchDescription:
                 ]
             ),
         ],
+        remappings=[
+            ("/controller_manager/robot_description", "/robot_description"),
+        ],
     )
 
     velocity_controller_spawner = Node(

--- a/blue_demos/control_integration/launch/bluerov2_heavy_controllers.launch.py
+++ b/blue_demos/control_integration/launch/bluerov2_heavy_controllers.launch.py
@@ -21,12 +21,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import (
-    Command,
-    FindExecutable,
-    LaunchConfiguration,
-    PathJoinSubstitution,
-)
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -51,29 +46,6 @@ def generate_launch_description() -> LaunchDescription:
         ),
     ]
 
-    robot_description_content = Command(
-        [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
-            " ",
-            PathJoinSubstitution(
-                [
-                    FindPackageShare("blue_demos"),
-                    "control_integration",
-                    "description",
-                    "urdf",
-                    "bluerov2_heavy.config.xacro",
-                ]
-            ),
-            " ",
-            "prefix:=",
-            LaunchConfiguration("prefix"),
-            " ",
-            "use_sim:=",
-            LaunchConfiguration("use_sim"),
-        ]
-    )
-    robot_description = {"robot_description": robot_description_content}
-
     # The ISMC expects state information to be provided in the FSD frame
     mobile_to_maritime_velocity_state = Node(
         package="mobile_to_maritime",
@@ -94,7 +66,6 @@ def generate_launch_description() -> LaunchDescription:
         executable="ros2_control_node",
         output="both",
         parameters=[
-            robot_description,
             PathJoinSubstitution(
                 [
                     FindPackageShare("blue_demos"),


### PR DESCRIPTION
## Changes Made

This PR adds a few fixes: some of which were recognized while I was debugging the build for Humble yesterday. The changes are as follows:
1. Fix the `ardupilot_gazebo` install. The dependencies have changed there and needed to be updated
2. Stopped passing the robot description file directly to the controller manager. This has been deprecated by the ros2_control team and needed to be fixed
3. Addressed a bad default path in the launch file for the BlueROV2 Heavy and Heavy Reach configurations

## Associated Issues

- Fixes #192 and other issues

## Testing

Testing was performed using Iron and Humble. Jazzy and Rolling are still being upgraded, so everything is broken there right now.
