### PR TITLE
xacro is an exec_depend for blue_description

### DIFF
--- a/blue_description/package.xml
+++ b/blue_description/package.xml
@@ -16,6 +16,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>xacro</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Changes Made

For the "robot" configuration (without Gazebo, etc) I found "xacro" needed to be installed manually / was an undeclared dependency.

This PR adds it as an `<exec_depend>` of `blue_description` to ensure it is installed by rosdep.

## Associated Issues

(none)

## Testing

Test by CI.