### PR TITLE
Use Gazebo Harmonic

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -120,7 +120,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV GZ_VERSION=harmonic
 
 # Install Gazebo Harmonic: https://gazebosim.org/docs/harmonic/install_ubuntu
-# Per DL3004, user USER rather than "sudo"
+# Per DL3004, use "USER root" rather than "sudo"
 #    https://github.com/hadolint/hadolint/wiki/DL3004
 USER root
 # Install custom rosdep list

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -105,32 +105,33 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV GZ_VERSION=harmonic
 
 # Install Gazebo Harmonic: https://gazebosim.org/docs/harmonic/install_ubuntu
-RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
-    && sudo apt-get -q update \
-    && sudo apt-get -y --quiet --no-install-recommends install \
+USER root
+# Install custom rosdep list
+ADD --chown=root:root --chmod=0644 https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list /etc/ros/rosdep/sources.list.d/00-gazebo.list
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" |  tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+    && apt-get -q update \
+    && apt-get -y --quiet --no-install-recommends install \
     gz-${GZ_VERSION} \
-    && sudo apt-get autoremove -y \
-    && sudo apt-get clean -y \
-    && sudo rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install ArduPilot and ardupilot_gazebo dependencies
-RUN sudo apt-get -q update \
-    && sudo apt-get -q -y upgrade \
-    && sudo apt-get -q install --no-install-recommends -y \
+RUN apt-get -q update \
+    && apt-get -q -y upgrade \
+    && apt-get -q install --no-install-recommends -y \
     python3-pexpect \
     python3-wxgtk4.0 \
     python3-future \
     rapidjson-dev \
     xterm \
-    libgz-sim?-dev \
-    gz-transport?? \
-    libgz-transport??-dev \
     rapidjson-dev \
     libopencv-dev \
-    && sudo apt-get autoremove -y \
-    && sudo apt-get clean -y \
-    && sudo rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+USER $USERNAME
 
 # Clone ArduSub
 # ArduSub is installed for simulation purposes ONLY
@@ -166,13 +167,11 @@ RUN [ "/bin/bash" , "-c" , " \
 
 # Install ros_gz and other project dependencies
 WORKDIR $USER_WORKSPACE
-# Some gz_* rosdep keys must be skipped because they are not in the rosdep yaml humble/iron
-# (despite the fact the packages are available).  Ensure they are installed manually.
 RUN sudo apt-get -q update \
     && sudo apt-get -q -y upgrade \
     && vcs import src < src/blue/blue.repos \
     && rosdep update \
-    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}  --skip-keys="gz-transport13 gz-sim8 gz-math7 gz-msgs10" \
+    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -102,14 +102,14 @@ RUN echo "source ${USER_WORKSPACE}/install/setup.bash" >> /home/$USERNAME/.bashr
 FROM robot AS desktop
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV GZ_VERSION=garden
+ENV GZ_VERSION=harmonic
 
-# Install Gazebo Garden: https://gazebosim.org/docs/garden/install_ubuntu
+# Install Gazebo Harmonic: https://gazebosim.org/docs/harmonic/install_ubuntu
 RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
     && sudo apt-get -q update \
     && sudo apt-get -y --quiet --no-install-recommends install \
-    gz-garden \
+    gz-${GZ_VERSION} \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*
@@ -118,10 +118,14 @@ RUN sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrin
 RUN sudo apt-get -q update \
     && sudo apt-get -q -y upgrade \
     && sudo apt-get -q install --no-install-recommends -y \
+    python3-pexpect \
     python3-wxgtk4.0 \
+    python3-future \
     rapidjson-dev \
     xterm \
-    libgz-sim7-dev \
+    libgz-sim?-dev \
+    gz-transport?? \
+    libgz-transport??-dev \
     rapidjson-dev \
     libopencv-dev \
     && sudo apt-get autoremove -y \
@@ -133,7 +137,10 @@ RUN sudo apt-get -q update \
 # When deployed onto hardware, the native installation of ArduSub
 # (on the FCU) will be used.
 WORKDIR /home/$USERNAME
-RUN git clone https://github.com/ArduPilot/ardupilot.git --recurse-submodules
+# Really should do version pinning but Sub-4.5 is waaaay behind master
+# (e.g. it doesn't know about "noble" yet)
+ARG ARDUPILOT_RELEASE=master
+RUN git clone -b ${ARDUPILOT_RELEASE} https://github.com/ArduPilot/ardupilot.git --recurse-submodules
 
 # Install ArduSub dependencies
 WORKDIR /home/$USERNAME/ardupilot
@@ -159,11 +166,13 @@ RUN [ "/bin/bash" , "-c" , " \
 
 # Install ros_gz and other project dependencies
 WORKDIR $USER_WORKSPACE
+# Some gz_* rosdep keys must be skipped because they are not in the rosdep yaml humble/iron
+# (despite the fact the packages are available).  Ensure they are installed manually.
 RUN sudo apt-get -q update \
     && sudo apt-get -q -y upgrade \
     && vcs import src < src/blue/blue.repos \
     && rosdep update \
-    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} \
+    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}  --skip-keys="gz-transport13 gz-sim8 gz-math7 gz-msgs10" \
     && sudo apt-get autoremove -y \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -120,6 +120,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV GZ_VERSION=harmonic
 
 # Install Gazebo Harmonic: https://gazebosim.org/docs/harmonic/install_ubuntu
+# Per DL3004, user USER rather than "sudo"
+#    https://github.com/hadolint/hadolint/wiki/DL3004
 USER root
 # Install custom rosdep list
 ADD --chown=root:root --chmod=0644 https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list /etc/ros/rosdep/sources.list.d/00-gazebo.list
@@ -128,14 +130,6 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
     && apt-get -q update \
     && apt-get -y --quiet --no-install-recommends install \
     gz-${GZ_VERSION} \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install ArduPilot and ardupilot_gazebo dependencies
-RUN apt-get -q update \
-    && apt-get -q -y upgrade \
-    && apt-get -q install --no-install-recommends -y \
     python3-pexpect \
     python3-wxgtk4.0 \
     python3-future \


### PR DESCRIPTION
## Changes Made

Updates to using Gazebo Harmonic by default.   Also includes:

- Minor dependencies for Harmonic
- ARG to specify Ardupilot / Ardusub version, however, it defaults to "master" (same as previous behavior)

Per the discussion in #170 this change _should_ propagate successfully to all ROS versions.   In the future, however, we may remove the manual build of `ros_gz` from source and instead use binary packages for `jazzy`, `iron` and `humble`.

## Associated Issues

- Addresses issue #170 

## Testing

Please provide a clear and concise description of the testing performed.
