### PR TITLE
Fix env format in Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -211,6 +211,6 @@ RUN sudo apt-get update \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Env vars for the nvidia-container-runtime.
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES graphics,utility,compute
-ENV QT_X11_NO_MITSHM 1
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=graphics,utility,compute
+ENV QT_X11_NO_MITSHM=1


### PR DESCRIPTION
## Changes Made

Fixes three ENVs into the preferred "key=value" format.

## Associated Issues

- Fixes #233 

## Testing

`docker build --check .` produces:

```
ci

Check complete, no warnings found.

desktop

Check complete, no warnings found.

desktop-nvidia

Check complete, no warnings found.

robot

Check complete, no warnings found.
```