### PR TITLE
Update and remove stale project configurations

### DIFF
--- a/.devcontainer/nouveau/devcontainer.json
+++ b/.devcontainer/nouveau/devcontainer.json
@@ -22,6 +22,11 @@
   },
   "customizations": {
     "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/home/ubuntu/.venv/blue/bin/python",
+        "python.autoComplete.extraPaths": ["${workspaceFolder}/install/"],
+        "python.analysis.extraPaths": ["${workspaceFolder}/install/"]
+      },
       "extensions": [
         "ms-azuretools.vscode-docker",
         "ms-python.python",

--- a/.devcontainer/nvidia/devcontainer.json
+++ b/.devcontainer/nvidia/devcontainer.json
@@ -26,6 +26,11 @@
   },
   "customizations": {
     "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/home/ubuntu/.venv/blue/bin/python",
+        "python.autoComplete.extraPaths": ["${workspaceFolder}/install/"],
+        "python.analysis.extraPaths": ["${workspaceFolder}/install/"]
+      },
       "extensions": [
         "ms-azuretools.vscode-docker",
         "ms-python.python",

--- a/.devcontainer/robot/devcontainer.json
+++ b/.devcontainer/robot/devcontainer.json
@@ -23,6 +23,11 @@
   "containerEnv": {},
   "customizations": {
     "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/home/ubuntu/.venv/blue/bin/python",
+        "python.autoComplete.extraPaths": ["${workspaceFolder}/install/"],
+        "python.analysis.extraPaths": ["${workspaceFolder}/install/"]
+      },
       "extensions": [
         "ms-azuretools.vscode-docker",
         "ms-python.python",

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,5 +1,5 @@
 name: Documentation Improvement
-description: Report an issue related to the BlueROV2 driver documentation.
+description: Report an issue related to the Blue documentation.
 title: "[DOC]: <Please write a descriptive title after the '[DOC]: ' prefix>"
 labels: [documentation, needs triage]
 
@@ -16,9 +16,9 @@ body:
       label: Documentation Change Type
       description: Please indicate what type of documentation issue you are reporting.
       options:
-        - Adding new documentation to the BlueROV2 driver documentation
-        - Changing existing BlueROV2 driver documentation
-        - Removing existing BlueROV2 driver documentation
+        - Adding new documentation to the Blue documentation
+        - Changing existing documentation
+        - Removing existing documentation
     validations:
       required: true
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: backport to iron at reviewers discretion
+  - name: backport to iron at reviewers' discretion
     conditions:
       - base=main
       - "label=backport-iron"
@@ -8,7 +8,7 @@ pull_request_rules:
         branches:
           - iron
 
-  - name: backport to humble at reviewers discretion
+  - name: backport to humble at reviewers' discretion
     conditions:
       - base=main
       - "label=backport-humble"
@@ -17,7 +17,7 @@ pull_request_rules:
         branches:
           - humble
 
-  - name: backport to jazzy at reviewers discretion
+  - name: backport to jazzy at reviewers' discretion
     conditions:
       - base=main
       - "label=backport-jazzy"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,15 @@ pull_request_rules:
         branches:
           - humble
 
+  - name: backport to jazzy at reviewers discretion
+    conditions:
+      - base=main
+      - "label=backport-jazzy"
+    actions:
+      backport:
+        branches:
+          - jazzy
+
   - name: ask to resolve conflict
     conditions:
       - conflict

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 33-feature-ros2-control
   pull_request:
     paths:
       - docs/**

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,12 +2,7 @@
   "configurations": [
     {
       "name": "Linux",
-      "includePath": [
-        "${workspaceFolder}/**",
-        "/opt/ros/rolling/include/**",
-        "/usr/include/eigen3/**",
-        "/home/ros/ws_ros/**"
-      ],
+      "includePath": ["${workspaceFolder}/**", "/opt/ros/rolling/include/**"],
       "defines": [],
       "compilerPath": "/usr/bin/gcc",
       "cStandard": "c99",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
       "name": "Linux",
       "includePath": [
         "${workspaceFolder}/**",
-        "/opt/ros/iron/include/**",
+        "/opt/ros/rolling/include/**",
         "/usr/include/eigen3/**",
         "/home/ros/ws_ros/**"
       ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,15 +23,16 @@
   "autoDocstring.startOnNewLine": false,
   "autoDocstring.docstringFormat": "google-notypes",
   "python.autoComplete.extraPaths": [
-    "/opt/ros/iron/lib/python3.10/site-packages/",
-    "/opt/ros/iron/local/lib/python3.10/dist-packages/",
+    "/opt/ros/rolling/lib/python3.10/site-packages/",
+    "/opt/ros/rolling/local/lib/python3.10/dist-packages/",
     "${workspaceFolder}/install/"
   ],
   "python.analysis.extraPaths": [
-    "/opt/ros/iron/lib/python3.10/site-packages/",
-    "/opt/ros/iron/local/lib/python3.10/dist-packages/",
+    "/opt/ros/rolling/lib/python3.10/site-packages/",
+    "/opt/ros/rolling/local/lib/python3.10/dist-packages/",
     "${workspaceFolder}/install/"
   ],
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/blue/bin/python",
   "[python]": {
     "editor.tabSize": 4,
     "editor.rulers": [90],
@@ -42,7 +43,6 @@
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/blue/bin/python",
   "[dockerfile]": {
     "editor.quickSuggestions": {
       "strings": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,15 +24,12 @@
   "autoDocstring.docstringFormat": "google-notypes",
   "python.autoComplete.extraPaths": [
     "/opt/ros/rolling/lib/python3.10/site-packages/",
-    "/opt/ros/rolling/local/lib/python3.10/dist-packages/",
-    "${workspaceFolder}/install/"
+    "/opt/ros/rolling/local/lib/python3.10/dist-packages/"
   ],
   "python.analysis.extraPaths": [
     "/opt/ros/rolling/lib/python3.10/site-packages/",
-    "/opt/ros/rolling/local/lib/python3.10/dist-packages/",
-    "${workspaceFolder}/install/"
+    "/opt/ros/rolling/local/lib/python3.10/dist-packages/"
   ],
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/blue/bin/python",
   "[python]": {
     "editor.tabSize": 4,
     "editor.rulers": [90],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,12 +23,12 @@
   "autoDocstring.startOnNewLine": false,
   "autoDocstring.docstringFormat": "google-notypes",
   "python.autoComplete.extraPaths": [
-    "/opt/ros/rolling/lib/python3.10/site-packages/",
-    "/opt/ros/rolling/local/lib/python3.10/dist-packages/"
+    "/opt/ros/rolling/lib/python3.12/site-packages/",
+    "/opt/ros/rolling/local/lib/python3.12/dist-packages/"
   ],
   "python.analysis.extraPaths": [
-    "/opt/ros/rolling/lib/python3.10/site-packages/",
-    "/opt/ros/rolling/local/lib/python3.10/dist-packages/"
+    "/opt/ros/rolling/lib/python3.12/site-packages/",
+    "/opt/ros/rolling/local/lib/python3.12/dist-packages/"
   ],
   "[python]": {
     "editor.tabSize": 4,


### PR DESCRIPTION
## Changes Made

This PR makes several updates to the project configurations to remove stale configurations and update update others, including

- Updating the `.vscode` configurations to use `rolling` instead of `iron`
- Fixing the documentation issue template
- Removing a stale branch from the documentation CI pipeline
- Moved devcontainer-specific Python configurations to the `devcontainer.json` files.