### PR TITLE
Add Docker BuildX config

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -170,6 +170,7 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
     xterm \
     rapidjson-dev \
     libopencv-dev \
+    cppzmq-dev \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -170,7 +170,6 @@ RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pk
     xterm \
     rapidjson-dev \
     libopencv-dev \
-    cppzmq-dev \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -32,6 +32,9 @@ target "ci" {
   tags = [
     "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-ci"
   ]
+  labels = {
+    "org.opencontainers.image.source" = "https://github.com/${BLUE_GITHUB_REPO}"
+  }
   cache_from =[
     "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-ci",
     "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-robot",

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -16,8 +16,14 @@ group "default" {
   targets = ["ci", "robot", "desktop", "desktop-nvidia"]
 }
 
-# In Github CI, populated by metadata-action Github action
-target "docker-metadata-action" {}
+# These are populated by the metadata-action Github action for each target
+# when building in CI
+#
+target "docker-metadata-action-ci" {}
+target "docker-metadata-action-robot" {}
+target "docker-metadata-action-desktop" {}
+target "docker-metadata-action-desktop-nvidia" {}
+
 
 #
 # All images can pull cache from the images published at Github
@@ -26,7 +32,7 @@ target "docker-metadata-action" {}
 # ... and push cache to local storage
 #
 target "ci" {
-  inherits = ["docker-metadata-action"]
+  inherits = ["docker-metadata-action-ci"]
   dockerfile = ".docker/Dockerfile"
   target = "ci"
   context = ".."
@@ -40,10 +46,10 @@ target "ci" {
     "org.opencontainers.image.source" = "https://github.com/${BLUE_GITHUB_REPO}"
   }
   cache_from =[
-    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-ci",
-    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-robot",
-    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop",
-    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop-nvidia",
+    "ghcr.io/${BLUE_GITHUB_REPO}:cache-${BLUE_ROS_DISTRO}-ci",
+    "ghcr.io/${BLUE_GITHUB_REPO}:cache-${BLUE_ROS_DISTRO}-robot",
+    "ghcr.io/${BLUE_GITHUB_REPO}:cache-${BLUE_ROS_DISTRO}-desktop",
+    "ghcr.io/${BLUE_GITHUB_REPO}:cache-${BLUE_ROS_DISTRO}-desktop-nvidia",
     "type=local,dest=.docker-cache"
   ]
   cache_to = [
@@ -53,7 +59,7 @@ target "ci" {
 }
 
 target "robot" {
-  inherits = [ "ci" ]
+  inherits = [ "ci", "docker-metadata-action-robot" ]
   target = "robot"
   tags = [
     "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-robot"
@@ -64,7 +70,7 @@ target "robot" {
 }
 
 target "desktop" {
-  inherits = [ "ci" ]
+  inherits = [ "ci", "docker-metadata-action-desktop" ]
   target = "desktop"
   tags = [
     "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop"
@@ -77,7 +83,7 @@ target "desktop" {
 }
 
 target "desktop-nvidia" {
-  inherits = [ "desktop" ]
+  inherits = [ "desktop", "docker-metadata-action-desktop-nvidia" ]
   target = "desktop-nvidia"
   tags = [
     "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop-nvidia"

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -16,6 +16,9 @@ group "default" {
   targets = ["ci", "robot", "desktop", "desktop-nvidia"]
 }
 
+# In Github CI, populated by metadata-action Github action
+target "docker-metadata-action" {}
+
 #
 # All images can pull cache from the images published at Github
 # or local storage (within the Buildkit image)
@@ -23,6 +26,7 @@ group "default" {
 # ... and push cache to local storage
 #
 target "ci" {
+  inherits = ["docker-metadata-action"]
   dockerfile = ".docker/Dockerfile"
   target = "ci"
   context = ".."

--- a/.docker/docker-bake.hcl
+++ b/.docker/docker-bake.hcl
@@ -1,0 +1,81 @@
+#
+# Override these variables with environment variables
+# e.g.
+#
+#   BLUE_ROS_DISTRO=iron docker buildx bake
+#
+# or
+#
+#   export BLUE_ROS_DISTRO=iron
+#   docker buildx bake
+#
+variable "BLUE_ROS_DISTRO" { default = "rolling" }
+variable "BLUE_GITHUB_REPO" { default = "robotic-decision-making-lab/blue" }
+
+group "default" {
+  targets = ["ci", "robot", "desktop", "desktop-nvidia"]
+}
+
+#
+# All images can pull cache from the images published at Github
+# or local storage (within the Buildkit image)
+#
+# ... and push cache to local storage
+#
+target "ci" {
+  dockerfile = ".docker/Dockerfile"
+  target = "ci"
+  context = ".."
+  args = {
+    ROS_DISTRO = "${BLUE_ROS_DISTRO}"
+  }
+  tags = [
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-ci"
+  ]
+  cache_from =[
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-ci",
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-robot",
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop",
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop-nvidia",
+    "type=local,dest=.docker-cache"
+  ]
+  cache_to = [
+    "type=local,dest=.docker-cache"
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "robot" {
+  inherits = [ "ci" ]
+  target = "robot"
+  tags = [
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-robot"
+  ]
+  cache_to = [
+    "type=local,dest=.docker-cache"
+  ]
+}
+
+target "desktop" {
+  inherits = [ "ci" ]
+  target = "desktop"
+  tags = [
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop"
+  ]
+  cache_to = [
+    "type=local,dest=.docker-cache"
+  ]
+  # amd64 only builds for desktop and desktop-nvidia
+  platforms = ["linux/amd64"]
+}
+
+target "desktop-nvidia" {
+  inherits = [ "desktop" ]
+  target = "desktop-nvidia"
+  tags = [
+    "ghcr.io/${BLUE_GITHUB_REPO}:${BLUE_ROS_DISTRO}-desktop-nvidia"
+  ]
+  cache_to = [
+    "type=local,dest=.docker-cache"
+  ]
+}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'apl-ocean-engineering/blue') }}
+  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'Robotic-Decision-Making-Lab/blue') }}
 
 jobs:
   ci:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,14 +24,13 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [rolling]
-        stage: ["ci", "robot", "desktop", "desktop-nvidia"]
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
     steps:
       -
-        name: Checkout repository
+        name: Checkout
         uses: actions/checkout@v4
 
       -
@@ -62,23 +61,50 @@ jobs:
         run: |
           echo "repository=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
 
-      # tbd:  not sure how to update this for buildx
-      #
-      # metadata-action can be used with bake:
-      #  https://github.com/docker/metadata-action?tab=readme-ov-file#bake-definition
-      #
-      # But not quite sure how to handle multiple targets given we don't iterate
-      # through the stages at this level (it happens within bake)
-      #
+      # Set metadata for each stage-image separately
       -
-        name: Extract Docker metadata
+        name: Set Docker metadata for "ci"
         if: env.PUSH == 'true'
-        id: meta
+        id: meta-ci
         uses: docker/metadata-action@v5.5.1
         with:
           images: ghcr.io/${{ github.repository }}
+          bake-target: docker-metadata-action-ci
           tags: |
-            type=raw,value=${{ matrix.ROS_DISTRO }}-${{ matrix.stage }}
+            type=raw,value=${{ matrix.ROS_DISTRO }}-ci
+
+      -
+        name: Set Docker metadata for "robot"
+        if: env.PUSH == 'true'
+        id: meta-robot
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+          bake-target: docker-metadata-action-robot
+          tags: |
+            type=raw,value=${{ matrix.ROS_DISTRO }}-robot
+
+      -
+        name: Set Docker metadata for "desktop"
+        if: env.PUSH == 'true'
+        id: meta-desktop
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+          bake-target: docker-metadata-action-desktop
+          tags: |
+            type=raw,value=${{ matrix.ROS_DISTRO }}-desktop
+
+      -
+        name: Set Docker metadata for "desktop-nvidia"
+        if: env.PUSH == 'true'
+        id: meta-desktop-nvidia
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+          bake-target: docker-metadata-action-desktop-nvidia
+          tags: |
+            type=raw,value=${{ matrix.ROS_DISTRO }}-desktop-nvidia
 
       - if: github.event_name == 'push'
         name: Build and push (non PR)
@@ -90,16 +116,14 @@ jobs:
           workdir: .docker
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: |
-            ${{ matrix.stage }}
+            ${{ steps.meta-ci.outputs.bake-file }}
+            ${{ steps.meta-robot.outputs.bake-file }}
+            ${{ steps.meta-desktop.outputs.bake-file }}
+            ${{ steps.meta-desktop-nvidia.outputs.bake-file }}
           push: ${{ env.PUSH }}
           set: |
-            *.cache-from=type=gha,scope=ci
-            *.cache-from=type=gha,scope=robot
-            *.cache-from=type=gha,scope=desktop
-            *.cache-from=type=gha,scope=desktop-nvidia
-            ${{ matrix.stage }}.cache-to=type=gha,mode=max,scope=${{ matrix.stage }}
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}:cache-${{ matrix.ROS_DISTRO }}
+            *.cache-to=type=registry,mode=max,ref=ghcr.io/${{ github.repository }}:cache-${{ matrix.ROS_DISTRO }}
 
       # Pull request builds are not cached; and only built for AMD64
       - if: github.event_name == 'pull_request'
@@ -112,13 +136,7 @@ jobs:
           workdir: .docker
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: |
-            ${{ matrix.stage }}
           set: |
             *.platform=linux/amd64
-            *.cache-from=type=gha,scope=ci
-            *.cache-from=type=gha,scope=robot
-            *.cache-from=type=gha,scope=desktop
-            *.cache-from=type=gha,scope=desktop-nvidia
+            *.cache-from=type=registry,ref=ghcr.io/${{ github.repository }}:cache-${{ matrix.ROS_DISTRO }}
             *.cache-to=

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'apl-ocean-engineering/blue') }}
+  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'Robotic-Decision-Making-Lab/blue') }}
 
 jobs:
   docker_build:
@@ -29,22 +29,18 @@ jobs:
       packages: write
       contents: read
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
-      -
-        # Add support for more platforms with QEMU (optional)
+      - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      -
-        if: env.PUSH == 'true'
+      - if: env.PUSH == 'true'
         name: Log into registry
         uses: docker/login-action@v3.3.0
         with:
@@ -56,14 +52,13 @@ jobs:
       # This shell ... er, hack, creates a local variable containing
       # a down-cased version of $GITHUB_REPOSITORY
       #
-      - id: lower-repo
+      - id: lowercase-repo
         name: Repository to lowercase
         run: |
           echo "repository=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
 
       # Set metadata for each stage-image separately
-      -
-        name: Set Docker metadata for "ci"
+      - name: Set Docker metadata for "ci"
         if: env.PUSH == 'true'
         id: meta-ci
         uses: docker/metadata-action@v5.5.1
@@ -73,8 +68,7 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.ROS_DISTRO }}-ci
 
-      -
-        name: Set Docker metadata for "robot"
+      - name: Set Docker metadata for "robot"
         if: env.PUSH == 'true'
         id: meta-robot
         uses: docker/metadata-action@v5.5.1
@@ -84,8 +78,7 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.ROS_DISTRO }}-robot
 
-      -
-        name: Set Docker metadata for "desktop"
+      - name: Set Docker metadata for "desktop"
         if: env.PUSH == 'true'
         id: meta-desktop
         uses: docker/metadata-action@v5.5.1
@@ -95,8 +88,7 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.ROS_DISTRO }}-desktop
 
-      -
-        name: Set Docker metadata for "desktop-nvidia"
+      - name: Set Docker metadata for "desktop-nvidia"
         if: env.PUSH == 'true'
         id: meta-desktop-nvidia
         uses: docker/metadata-action@v5.5.1
@@ -111,7 +103,7 @@ jobs:
         uses: docker/bake-action@v5.5.0
         env:
           BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
-          BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
+          BLUE_GITHUB_REPO: ${{ steps.lowercase-repo.outputs.repository }}
         with:
           workdir: .docker
           files: |
@@ -131,7 +123,7 @@ jobs:
         uses: docker/bake-action@v5.5.0
         env:
           BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
-          BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
+          BLUE_GITHUB_REPO: ${{ steps.lowercase-repo.outputs.repository }}
         with:
           workdir: .docker
           files: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,7 +84,7 @@ jobs:
             desktop-nvidia.cache-to=type=gha,mode=max,scope=desktop-nvidia
 
       # Pull request builds are not cached; and only built for AMD64
-      - if: (github.event_name == 'pull_request') || (workflow_dispath)
+      - if: github.event_name == 'pull_request'
         name: Build and push (PR)
         uses: docker/bake-action@v5.5.0
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,9 +28,6 @@ jobs:
     permissions:
       packages: write
       contents: read
-    env:
-      BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
-      BLUE_GITHUB_REPO: ${{ github.repository }}
     steps:
       -
         name: Checkout repository
@@ -55,6 +52,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - id: lower-repo
+        name: Repository to lowercase
+        run: |
+          echo "repository=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
+
       # tbd:  not sure how to update this for buildx
       #
       # -
@@ -70,6 +72,9 @@ jobs:
       - if: github.event_name == 'push'
         name: Build and push (non PR)
         uses: docker/bake-action@v5.5.0
+        env:
+          BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+          BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
         with:
           workdir: .docker
           push: ${{ env.PUSH }}
@@ -87,6 +92,9 @@ jobs:
       - if: github.event_name == 'pull_request'
         name: Build and push (PR)
         uses: docker/bake-action@v5.5.0
+        env:
+          BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+          BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
         with:
           workdir: .docker
           targets: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,7 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [rolling]
-        stage: ["ci", "robot", "desktop", "desktop-nvidia"]
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,8 +1,8 @@
 name: Docker
 
 on:
-  schedule:
-    - cron: "0 17 * * 6"
+  # schedule:
+  #   - cron: "0 17 * * 6"
   push:
     branches:
       - main
@@ -15,10 +15,10 @@ on:
   workflow_dispatch:
 
 env:
-  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'Robotic-Decision-Making-Lab/blue') }}
+  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'apl-ocean-engineering/blue') }}
 
 jobs:
-  ci:
+  docker_build:
     strategy:
       fail-fast: false
       matrix:
@@ -27,165 +27,71 @@ jobs:
     permissions:
       packages: write
       contents: read
+    env:
+      BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+      BLUE_GITHUB_REPO: ${{ github.repository }}
     steps:
-      - name: Checkout repository
+      -
+        name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log into registry
-        if: env.PUSH == 'true'
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Extract Docker metadata
-        if: env.PUSH == 'true'
-        id: meta
-        uses: docker/metadata-action@v5.5.1
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ matrix.ROS_DISTRO }}-${{ github.job }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.7.0
-        with:
-          context: .
-          file: .docker/Dockerfile
-          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-          target: ${{ github.job }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ env.PUSH }}
-
-  robot:
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: [rolling]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.2.0
-
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry
+      -
         if: env.PUSH == 'true'
+        name: Log into registry
         uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        if: env.PUSH == 'true'
-        id: meta
-        uses: docker/metadata-action@v5.5.1
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ matrix.ROS_DISTRO }}-${{ github.job }}
+      # -
+      #   name: Extract Docker metadata
+      #   if: env.PUSH == 'true'
+      #   id: meta
+      #   uses: docker/metadata-action@v5.5.1
+      #   with:
+      #     images: ghcr.io/${{ github.repository }}
+      #     tags: |
+      #       type=raw,value=${{ matrix.ROS_DISTRO }}-${{ matrix.stage }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.7.0
+      - if: github.event_name == 'push'
+        name: Build and push (non PR)
+        uses: docker/bake-action@v5.5.0
         with:
-          context: .
-          file: .docker/Dockerfile
-          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-          target: ${{ github.job }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          workdir: .docker
           push: ${{ env.PUSH }}
-          platforms: linux/amd64
-          #platforms: linux/amd64,linux/arm64
+          set: |
+            *.platform=linux/amd64
+            *.cache-from=type=gha,scope=ci
+            *.cache-from=type=gha,scope=robot
+            *.cache-from=type=gha,scope=desktop
+            *.cache-from=type=gha,scope=desktop-nvidia
+            ci.cache-to=type=gha,mode=max,scope=ci
+            robot.cache-to=type=gha,mode=max,scope=robot
+            desktop.cache-to=type=gha,mode=max,scope=desktop
+            desktop-nvidia.cache-to=type=gha,mode=max,scope=desktop-nvidia
 
-  desktop:
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: [rolling]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log into registry
-        if: env.PUSH == 'true'
-        uses: docker/login-action@v3.3.0
+      - if: github.event_name == 'pull_request'
+        name: Build and push (PR)
+        uses: docker/bake-action@v5.5.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        if: env.PUSH == 'true'
-        id: meta
-        uses: docker/metadata-action@v5.5.1
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ matrix.ROS_DISTRO }}-${{ github.job }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.7.0
-        with:
-          context: .
-          file: .docker/Dockerfile
-          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-          target: ${{ github.job }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ env.PUSH }}
-
-  desktop-nvidia:
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: [rolling]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log into registry
-        if: env.PUSH == 'true'
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        if: env.PUSH == 'true'
-        id: meta
-        uses: docker/metadata-action@v5.5.1
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{ matrix.ROS_DISTRO }}-${{ github.job }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6.7.0
-        with:
-          context: .
-          file: .docker/Dockerfile
-          build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-          target: ${{ github.job }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ env.PUSH }}
+          workdir: .docker
+          targets: |
+            ${{ matrix.stage }}
+          set: |
+            *.platform=linux/amd64
+            *.cache-from=type=gha,scope=ci
+            *.cache-from=type=gha,scope=robot
+            *.cache-from=type=gha,scope=desktop
+            *.cache-from=type=gha,scope=desktop-nvidia
+            *.cache-to=

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -52,6 +52,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # buildx bake, unfortunately, requires lower-cased repository names
+      # This shell ... er, hack, creates a local variable containing
+      # a down-cased version of $GITHUB_REPOSITORY
+      #
       - id: lower-repo
         name: Repository to lowercase
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [rolling]
+        stage: ["ci", "robot", "desktop", "desktop-nvidia"]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -63,19 +64,28 @@ jobs:
 
       # tbd:  not sure how to update this for buildx
       #
-      # -
-      #   name: Extract Docker metadata
-      #   if: env.PUSH == 'true'
-      #   id: meta
-      #   uses: docker/metadata-action@v5.5.1
-      #   with:
-      #     images: ghcr.io/${{ github.repository }}
-      #     tags: |
-      #       type=raw,value=${{ matrix.ROS_DISTRO }}-${{ matrix.stage }}
+      # metadata-action can be used with bake:
+      #  https://github.com/docker/metadata-action?tab=readme-ov-file#bake-definition
+      #
+      # But not quite sure how to handle multiple targets given we don't iterate
+      # through the stages at this level (it happens within bake)
+      #
+      -
+        name: Extract Docker metadata
+        if: env.PUSH == 'true'
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ matrix.ROS_DISTRO }}-${{ matrix.stage }}
 
       - if: github.event_name == 'push'
         name: Build and push (non PR)
         uses: docker/bake-action@v5.5.0
+        files: |
+          .docker/docker-bake.hcl
+          ${{ steps.meta.outputs.bake-file }}
         env:
           BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
           BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
@@ -87,15 +97,15 @@ jobs:
             *.cache-from=type=gha,scope=robot
             *.cache-from=type=gha,scope=desktop
             *.cache-from=type=gha,scope=desktop-nvidia
-            ci.cache-to=type=gha,mode=max,scope=ci
-            robot.cache-to=type=gha,mode=max,scope=robot
-            desktop.cache-to=type=gha,mode=max,scope=desktop
-            desktop-nvidia.cache-to=type=gha,mode=max,scope=desktop-nvidia
+            ${{ matrix.stage }}.cache-to=type=gha,mode=max,scope=${{ matrix.stage }}
 
       # Pull request builds are not cached; and only built for AMD64
       - if: github.event_name == 'pull_request'
         name: Build and push (PR)
         uses: docker/bake-action@v5.5.0
+        files: |
+          .docker/docker-bake.hcl
+          ${{ steps.meta.outputs.bake-file }}
         env:
           BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
           BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,7 +84,7 @@ jobs:
             desktop-nvidia.cache-to=type=gha,mode=max,scope=desktop-nvidia
 
       # Pull request builds are not cached; and only built for AMD64
-      - if: github.event_name == 'pull_request'
+      - if: (github.event_name == 'pull_request') || (workflow_dispath)
         name: Build and push (PR)
         uses: docker/bake-action@v5.5.0
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -83,14 +83,16 @@ jobs:
       - if: github.event_name == 'push'
         name: Build and push (non PR)
         uses: docker/bake-action@v5.5.0
-        files: |
-          .docker/docker-bake.hcl
-          ${{ steps.meta.outputs.bake-file }}
         env:
           BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
           BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
         with:
           workdir: .docker
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: |
+            ${{ matrix.stage }}
           push: ${{ env.PUSH }}
           set: |
             *.cache-from=type=gha,scope=ci
@@ -103,14 +105,14 @@ jobs:
       - if: github.event_name == 'pull_request'
         name: Build and push (PR)
         uses: docker/bake-action@v5.5.0
-        files: |
-          .docker/docker-bake.hcl
-          ${{ steps.meta.outputs.bake-file }}
         env:
           BLUE_ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
           BLUE_GITHUB_REPO: ${{ steps.lower-repo.outputs.repository }}
         with:
           workdir: .docker
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
           targets: |
             ${{ matrix.stage }}
           set: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'Robotic-Decision-Making-Lab/blue') }}
+  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'apl-ocean-engineering/blue') }}
 
 jobs:
   ci:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  # Disable schedule for preliminary testing
   # schedule:
   #   - cron: "0 17 * * 6"
   push:
@@ -15,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'apl-ocean-engineering/blue') }}
+  PUSH: ${{ (github.event_name != 'pull_request') && (github.repository == 'Robotic-Decision-Making-Lab/blue') }}
 
 jobs:
   docker_build:
@@ -54,6 +55,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # tbd:  not sure how to update this for buildx
+      #
       # -
       #   name: Extract Docker metadata
       #   if: env.PUSH == 'true'
@@ -71,7 +74,6 @@ jobs:
           workdir: .docker
           push: ${{ env.PUSH }}
           set: |
-            *.platform=linux/amd64
             *.cache-from=type=gha,scope=ci
             *.cache-from=type=gha,scope=robot
             *.cache-from=type=gha,scope=desktop
@@ -81,6 +83,7 @@ jobs:
             desktop.cache-to=type=gha,mode=max,scope=desktop
             desktop-nvidia.cache-to=type=gha,mode=max,scope=desktop-nvidia
 
+      # Pull request builds are not cached; and only built for AMD64
       - if: github.event_name == 'pull_request'
         name: Build and push (PR)
         uses: docker/bake-action@v5.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ mav.parm
 mav.tlog
 mav.tlog.raw
 logs/
+
+# Allow overrides in docker-bake
+.docker/docker-bake.override.hcl


### PR DESCRIPTION
## Changes Made

Adds a `.docker/docker-bake.hcl` buildx bake configuration file.   The default behavior is to pulls images from `ghcr.io/robotic-decision-making-lab/blue` to prime the cache, but only _push_ to local cache.

Also updates the Github action to use buildx-bake.   In CI it overrides the default config to cache to/from images in the Github package registry.

All docker images ('ci', 'robot', 'desktop' and 'desktop-nvidia') can be built with:

```
cd .docker && docker buildx bake
```

This is a standalone PR with the buildx config;  very similar files are commited in the more complex #241.   If merged, this will lead to a conflict in that PR which will need to be managed by hand.

## Associated Issues

Related to #241 

## Testing

Above `docker buildx bake` call completes successfully.  Resulting images for `rolling` are functional to complete joystick teleop demo.