### PR TITLE
Added ament hooks for Gazebo models and worlds

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -243,13 +243,6 @@ export GZ_SIM_SYSTEM_PLUGIN_PATH=\$HOME/ardupilot_gazebo/build:\$GZ_SIM_SYSTEM_P
 
 # Add ardupilot_gazebo models and worlds
 export GZ_SIM_RESOURCE_PATH=\$HOME/ardupilot_gazebo/models:\$HOME/ardupilot_gazebo/worlds:\$GZ_SIM_RESOURCE_PATH
-
-# Add blue models and worlds
-BLUE_DESCRIPTION=\$USER_WORKSPACE/src/blue/blue_description
-export GZ_SIM_RESOURCE_PATH=\$BLUE_DESCRIPTION/gazebo/models:\$BLUE_DESCRIPTION/gazebo/worlds:\$GZ_SIM_RESOURCE_PATH
-
-# Add blue meshes
-export GZ_SIM_RESOURCE_PATH=\$BLUE_DESCRIPTION/meshes:\$GZ_SIM_RESOURCE_PATH
 EOT
 
 FROM desktop AS desktop-nvidia

--- a/blue_description/CMakeLists.txt
+++ b/blue_description/CMakeLists.txt
@@ -8,4 +8,6 @@ install(
   DESTINATION share/blue_description
 )
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/hooks.dsv.in")
+
 ament_package()

--- a/blue_description/hooks/hooks.dsv.in
+++ b/blue_description/hooks/hooks.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/gazebo/models
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/gazebo/worlds


### PR DESCRIPTION
## Changes Made

Adds ament hooks to update the `GZ_SIM_RESOURCE_PATH` with the paths needed to discover the added models and worlds. Hooks were not added for the `ardupilot_gazebo` package--this should be done in a separate PR that tracks additions to `ardusub_driver`.

## Associated Issues

- Fixes #294 

## Testing

Testing was done with Docker and the BlueROV2 in Gazebo to verify that all models are properly loaded.
