### PR TITLE
Integrate latest mobile_to_maritime API

### DIFF
--- a/blue_demos/teleoperation/config/joy_teleop.yaml
+++ b/blue_demos/teleoperation/config/joy_teleop.yaml
@@ -8,7 +8,7 @@ joy_teleop:
     manual_control:
       type: topic
       interface_type: geometry_msgs/msg/Twist
-      topic_name: cmd_vel
+      topic_name: /cmd_vel
       deadman_axes: [2]
       axis_mappings:
         linear-x:

--- a/blue_demos/teleoperation/config/transforms.yaml
+++ b/blue_demos/teleoperation/config/transforms.yaml
@@ -1,0 +1,10 @@
+message_transforms:
+  ros__parameters:
+
+    incoming_topics:
+      - /cmd_vel
+
+    transforms:
+      /cmd_vel:
+        outgoing_topic: /integral_sliding_mode_controller/reference
+        message_type: geometry_msgs/msg/Twist

--- a/blue_demos/teleoperation/launch/joy_teleop.launch.yaml
+++ b/blue_demos/teleoperation/launch/joy_teleop.launch.yaml
@@ -5,8 +5,8 @@ launch:
       default: $(find-pkg-share blue_demos)/teleoperation/config/joy_teleop.yaml
 
   - arg:
-      name: use_maritime
-      default: "true"
+      name: transforms_file
+      default: $(find-pkg-share blue_demos)/teleoperation/config/transforms.yaml
 
   - node:
       pkg: joy_linux
@@ -22,12 +22,9 @@ launch:
       param:
         - from: $(var joy_file)
 
-  - node:
-      pkg: mobile_to_maritime
-      exec: mobile_twist_to_maritime_twist
-      param:
-        - name: in_topic
-          value: cmd_vel
-        - name: out_topic
-          value: /integral_sliding_mode_controller/reference
-      if: $(var use_maritime)
+  # Launch the message transforms
+  - include:
+      file: $(find-pkg-share message_transforms)/launch/message_transforms.launch.py
+      arg:
+        - name: parameters_file
+          value: $(var params_file)

--- a/blue_demos/teleoperation/launch/joy_teleop.launch.yaml
+++ b/blue_demos/teleoperation/launch/joy_teleop.launch.yaml
@@ -22,7 +22,6 @@ launch:
       param:
         - from: $(var joy_file)
 
-  # Launch the message transforms
   - include:
       file: $(find-pkg-share message_transforms)/launch/message_transforms.launch.py
       arg:

--- a/blue_demos/teleoperation/launch/joy_teleop.launch.yaml
+++ b/blue_demos/teleoperation/launch/joy_teleop.launch.yaml
@@ -27,4 +27,4 @@ launch:
       file: $(find-pkg-share message_transforms)/launch/message_transforms.launch.py
       arg:
         - name: parameters_file
-          value: $(var params_file)
+          value: $(var transforms_file)

--- a/docs/docs/tutorials/teleop.mdx
+++ b/docs/docs/tutorials/teleop.mdx
@@ -51,10 +51,17 @@ Docker as described in the [installation instructions](/installation).
    [REP-105](https://ros.org/reps/rep-0105.html); however, the launched ISMC
    adheres to the maritime conventions recorded in [REP-156](https://github.com/ros-infrastructure/rep/pull/398).
    To convert the velocity commands to the appropriate convention, run the
-   following `mobile_to_maritime` message filter in a new terminal:
+   `message_transforms` node in a new terminal:
 
    ```bash
-   ros2 run mobile_to_maritime mobile_twist_to_maritime_twist --ros-args -p in_topic:=/cmd_vel -p out_topic:=/integral_sliding_mode_controller/reference
+   ros2 launch message_transforms message_transforms.launch.py parameters_file:=<path/to/transforms.yaml>
+   ```
+
+   where `<path/to/transforms.yaml>` should be replaced with the path to the
+   `transforms.yaml` file in the `blue_demos` package, e.g.,
+
+   ```bash
+   ros2 launch message_transforms message_transforms.launch.py parameters_file:=./blue_demos/teleoperation/config/transforms.yaml
    ```
 
 5. You should now be able to teleoperate the BlueROV2 using your keyboard.


### PR DESCRIPTION
## Changes Made

This PR updates the demos to use the latest version of `mobile_to_maritime`.

## Associated Issues

- Fixes #309 

## Testing

Testing was done with both teleop demos.
