### PR TITLE
Jazzy Nvidia GPU Bug Fix

### DIFF
--- a/.devcontainer/nvidia/Dockerfile
+++ b/.devcontainer/nvidia/Dockerfile
@@ -1,5 +1,16 @@
 FROM ghcr.io/robotic-decision-making-lab/blue:jazzy-desktop-nvidia
 
+
+USER root
+
+# Setup ROS2 repository and update package lists
+RUN rm -f /etc/apt/sources.list.d/ros2*.list || true && \
+    apt-key del F42ED6FBAB17C654 || true && \
+    rm -f /usr/share/keyrings/ros*-archive-keyring.gpg || true && \
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null && \
+    apt-get update
+
 # Install ROS dependencies
 # This is done in a previous stage, but we include it again here in case anyone wants to
 # add new dependencies during development

--- a/.devcontainer/nvidia/Dockerfile
+++ b/.devcontainer/nvidia/Dockerfile
@@ -1,26 +1,21 @@
 FROM ghcr.io/robotic-decision-making-lab/blue:jazzy-desktop-nvidia
 
-
-USER root
-
-# Setup ROS2 repository and update package lists
-RUN rm -f /etc/apt/sources.list.d/ros2*.list || true && \
-    apt-key del F42ED6FBAB17C654 || true && \
-    rm -f /usr/share/keyrings/ros*-archive-keyring.gpg || true && \
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null && \
-    apt-get update
-
 # Install ROS dependencies
 # This is done in a previous stage, but we include it again here in case anyone wants to
 # add new dependencies during development
 ENV USERNAME=ubuntu
 ENV USER_WORKSPACE=/home/$USERNAME/ws_blue
+ENV USER_GID=1000
+ENV USER_UID=1000
 WORKDIR $USER_WORKSPACE
 
 COPY --chown=$USER_UID:$USER_GID . src/blue
+
+ENV ROS2_LATEST_ARCHIVE_KEYRING="/usr/share/keyrings/ros2-latest-archive-keyring.gpg"
+RUN sudo rm -f ${ROS2_LATEST_ARCHIVE_KEYRING}
+RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o ${ROS2_LATEST_ARCHIVE_KEYRING}
+
 RUN sudo apt-get -q update \
-    && sudo apt-get -q -y upgrade \
     && rosdep update \
     && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --skip-keys="gz-transport12 gz-sim7 gz-math7 gz-msgs9 gz-plugin2" \
     && sudo apt-get autoremove -y \

--- a/.devcontainer/nvidia/devcontainer.json
+++ b/.devcontainer/nvidia/devcontainer.json
@@ -14,6 +14,7 @@
     "--privileged",
     "--volume=/tmp/.X11-unix:/tmp/.X11-unix",
     "--volume=/mnt/wslg:/mnt/wslg",
+    "--runtime=nvidia",
     "--gpus=all"
   ],
   "containerEnv": {
@@ -22,7 +23,12 @@
     "XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
     "PULSE_SERVER": "${localEnv:PULSE_SERVER}",
     "LIBGL_ALWAYS_SOFTWARE": "1",
-    "QT_X11_NO_MITSHM": "1"
+    "QT_X11_NO_MITSHM": "1",
+    "NVIDIA_VISIBLE_DEVICES": "all",
+    "NVIDIA_DRIVER_CAPABILITIES": "all",
+    "__GLX_VENDOR_LIBRARY_NAME": "nvidia",
+    "__NV_PRIME_RENDER_OFFLOAD": "1",
+    "__VK_LAYER_NV_optimus": "NVIDIA_only"
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Changes Made

Added params to `.devcontainer/nvidia/devcontainer.json`. 
Edited `.devcontainer/nvidia/Dockerfile` to support updated ROS2 signing keys.

## Associated Issues

1. https://github.com/Robotic-Decision-Making-Lab/blue/issues/390

- Fixes # (issue)
Able to access NVIDIA GPU inside of docker where the docker is running on Ubuntu 24.04 LTS
Added ROS2 signing keys

## Testing

This fix has been tested on `main` and `jazzy` branch. 

On `jazzy`:
It completely fixed the issue and I could see the PIDs for gazebo processes on nvidia-smi. The RTF is above 98%.

On `main`:
After upgrading to Gazebo Ionic along with this fix, the blueROV gets spawned in Gazebo but it still shows the Ardupilot version incompatibility error.

<img width="938" height="538" alt="image" src="https://github.com/user-attachments/assets/e1647ac1-2996-422c-860e-edc9e9081ca0" />
<img width="1380" height="870" alt="image" src="https://github.com/user-attachments/assets/fc977084-cba7-41e6-83ed-3ed0dbbe80f1" />
