### PR TITLE
Nvidia GPU Bug Fix

### DIFF
--- a/.devcontainer/nvidia/devcontainer.json
+++ b/.devcontainer/nvidia/devcontainer.json
@@ -14,6 +14,7 @@
     "--privileged",
     "--volume=/tmp/.X11-unix:/tmp/.X11-unix",
     "--volume=/mnt/wslg:/mnt/wslg",
+    "--runtime=nvidia",
     "--gpus=all"
   ],
   "containerEnv": {
@@ -22,14 +23,23 @@
     "XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
     "PULSE_SERVER": "${localEnv:PULSE_SERVER}",
     "LIBGL_ALWAYS_SOFTWARE": "1",
-    "QT_X11_NO_MITSHM": "1"
+    "QT_X11_NO_MITSHM": "1",
+    "NVIDIA_VISIBLE_DEVICES": "all",
+    "NVIDIA_DRIVER_CAPABILITIES": "all",
+    "__GLX_VENDOR_LIBRARY_NAME": "nvidia",
+    "__NV_PRIME_RENDER_OFFLOAD": "1",
+    "__VK_LAYER_NV_optimus": "NVIDIA_only"
   },
   "customizations": {
     "vscode": {
       "settings": {
         "python.defaultInterpreterPath": "/home/ubuntu/.venv/blue/bin/python",
-        "python.autoComplete.extraPaths": ["${workspaceFolder}/install/"],
-        "python.analysis.extraPaths": ["${workspaceFolder}/install/"]
+        "python.autoComplete.extraPaths": [
+          "${workspaceFolder}/install/"
+        ],
+        "python.analysis.extraPaths": [
+          "${workspaceFolder}/install/"
+        ]
       },
       "extensions": [
         "ms-azuretools.vscode-docker",


### PR DESCRIPTION
## Changes Made

Added params to `.devcontainer/nvidia/devcontainer.json`. 

## Associated Issues

- Fixes #390 

## Testing

This fix has been tested on `main` and `jazzy` branch.  I could see the PIDs for gazebo processes on nvidia-smi. The RTF is above 98%. 

<img width="938" height="538" alt="image" src="https://github.com/user-attachments/assets/e1647ac1-2996-422c-860e-edc9e9081ca0" />
